### PR TITLE
Don't switch to tmux session if popup selector is closed

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -41,19 +41,19 @@ bind-key j choose-tree -swZ
 bind C-j new-window -n "session-switcher" "\
     tmux list-sessions -F '#{?session_attached,,#{session_name}}' |\
     sed '/^$/d' |\
-    fzf --reverse --header jump-to-session --preview 'tmux capture-pane -pt {}'  |\
-    xargs tmux switch-client -t"
+    fzf --reverse --header jump-to-session --preview 'tmux capture-pane -pt {}' \
+    	--bind 'enter:execute(tmux switch-client -t {})+accept'"
 # popup
 bind C-j display-popup -E "\
     tmux list-sessions -F '#{?session_attached,,#{session_name}}' |\
     sed '/^$/d' |\
-    fzf --reverse --header jump-to-session --preview 'tmux capture-pane -pt {}'  |\
-    xargs tmux switch-client -t"
+    fzf --reverse --header jump-to-session --preview 'tmux capture-pane -pt {}' \
+    	--bind 'enter:execute(tmux switch-client -t {})+accept'"
 bind -n M-f display-popup -E "\
     tmux list-sessions -F '#{?session_attached,,#{session_name}}' |\
     sed '/^$/d' |\
-    fzf --reverse --header jump-to-session --preview 'tmux capture-pane -pt {}'  |\
-    xargs tmux switch-client -t"
+    fzf --reverse --header jump-to-session --preview 'tmux capture-pane -pt {}' \
+    	--bind 'enter:execute(tmux switch-client -t {})+accept'"
 
 bind -n M-f display-popup -h 95% -w 95% "git commit --verbose"
 bind -n M-F display-popup -h 95% -w 95% -d '#{pane_current_path}' -E 'gitui'


### PR DESCRIPTION
Your fzf session jumper is awesome and I've used it thousands of times. However, it had the annoying behaviour of switching to a session even if the fzf popup is closed (with Esc or Ctrl+C).

This commit changes that by only executing `tmux switch-client` on 'enter', meaning that a cancel will simply quit the fzf popup and leave you in the current session.

I tested your config briefly to check that it works, I didn't manage to test the `bind -n M-f` binding. Since the code was equal I assumed that it works, but this wasn't tested.